### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN make darkhttpd-static \
 FROM scratch
 WORKDIR /www-root
 COPY --from=build /src/darkhttpd-static /darkhttpd
+EXPOSE 80
 ENTRYPOINT ["/darkhttpd"]
+CMD ["."]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN make darkhttpd-static \
 
 # Just the static binary
 FROM scratch
-WORKDIR /www-root
+WORKDIR /var/www/htdocs
 COPY --from=build /src/darkhttpd-static /darkhttpd
 EXPOSE 80
 ENTRYPOINT ["/darkhttpd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build environment
+FROM alpine AS build
+RUN apk add --no-cache build-base
+WORKDIR /src
+COPY . .
+RUN make darkhttpd-static \
+ && strip darkhttpd-static
+
+# Just the static binary
+FROM scratch
+WORKDIR /www-root
+COPY --from=build /src/darkhttpd-static /darkhttpd
+ENTRYPOINT ["/darkhttpd"]

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ darkhttpd: darkhttpd.c
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LIBS) darkhttpd.c -o $@
 
 darkhttpd-static: darkhttpd.c
-        $(CC) -static $(CFLAGS) $(LDFLAGS) $(LIBS) darkhttpd.c -o $@
+	$(CC) -static $(CFLAGS) $(LDFLAGS) $(LIBS) darkhttpd.c -o $@
 
 clean:
 	rm -f darkhttpd core darkhttpd.core darkhttpd-static darkhttpd-static.core

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,10 @@ all: darkhttpd
 darkhttpd: darkhttpd.c
 	$(CC) $(CFLAGS) $(LDFLAGS) $(LIBS) darkhttpd.c -o $@
 
+darkhttpd-static: darkhttpd.c
+        $(CC) -static $(CFLAGS) $(LDFLAGS) $(LIBS) darkhttpd.c -o $@
+
 clean:
-	rm -f darkhttpd core darkhttpd.core
+	rm -f darkhttpd core darkhttpd.core darkhttpd-static darkhttpd-static.core
 
 .PHONY: all clean

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Features:
 * At some point worked on FreeBSD, Linux, OpenBSD, Solaris.
 * ISC license.
 * suckless.org says [darkhttpd sucks less](http://suckless.org/rocks/).
+* Small Docker image (<100KB)
 
 Security:
 * Can log accesses, including Referer and User-Agent.

--- a/README.md
+++ b/README.md
@@ -143,4 +143,17 @@ run darkhttpd without any arguments:
 ./darkhttpd
 ```
 
+## How to run darkhttpd in Docker
+
+First, build the image.
+```
+docker build -t darkhttpd .
+```
+Then run using volumes for the served files and port mapping for access.
+
+For example, the following would serve files from the current user's dev/mywebsite directory on http://localhost:8080/
+```
+docker run -p 8080:80 -v ~/dev/mywebsite:/var/www/htdocs:ro darkhttpd
+```
+
 Enjoy.


### PR DESCRIPTION
Add static build option to Makefile and create Dockerfile to run it. Users could simply map the containers `/var/www/htdocs` directory or copy files directly to the container using standard Docker image extension.