### PR TITLE
Properly divide list "headers" and lists.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ https://unix4lyfe.org/darkhttpd/
 When you need a web server in a hurry.
 
 Features:
+
 * Simple to set up:
   * Single binary, no other files, no installation needed.
   * Standalone, doesn't need `inetd` or `ucspi-tcp`.
@@ -27,6 +28,7 @@ Features:
 * Small Docker image (<100KB)
 
 Security:
+
 * Can log accesses, including Referer and User-Agent.
 * Can chroot.
 * Can drop privileges.
@@ -35,6 +37,7 @@ Security:
 * Drops overly long requests.
 
 Limitations:
+
 * Only serves static content - no CGI.
 
 ## How to build darkhttpd


### PR DESCRIPTION
Since the feature (and security and limitations) list follows the
"Features:" (etc.) line without any empty lines between them,
some Markdown-to-HTML converters (correctly) assume that
they are one paragraph, which causes the list not to
be converted to an actual HTML list. By putting an empty line
between the actual lists and their preceding lines,
the lists will be correctly converted.

(Both lists and paragraphs are block elements,
and they should be "marked down" accordingly.
See https://daringfireball.net/projects/markdown/syntax#block .)