### PR TITLE
Fix hung connection from consecutive requests

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,3 +1,1 @@
-- keepalive performance against ab sucks
-- keepalive+TCP_NODELAY hangs!
 - send headers using sendfile syscall - fewer packets

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -2576,19 +2576,14 @@ static void httpd_poll(void) {
         }
 
         /* Handling SEND_REPLY could have set the state to done. */
-        while (conn->state == DONE) {
+        if (conn->state == DONE) {
             /* clean out finished connection */
             if (conn->conn_close) {
                 LIST_REMOVE(conn, entries);
                 free_connection(conn);
                 free(conn);
-                break;
             } else {
                 recycle_connection(conn);
-                /* and go right back to recv_request without going through
-                 * select() again, until state is not DONE
-                 */
-                poll_recv_request(conn);
             }
         }
     }

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -817,13 +817,11 @@ static void init_sockin(void) {
                    &sockopt, sizeof(sockopt)) == -1)
         err(1, "setsockopt(SO_REUSEADDR)");
 
-#if 0
     /* disable Nagle since we buffer everything ourselves */
     sockopt = 1;
     if (setsockopt(sockin, IPPROTO_TCP, TCP_NODELAY,
             &sockopt, sizeof(sockopt)) == -1)
         err(1, "setsockopt(TCP_NODELAY)");
-#endif
 
 #ifdef TORTURE
     /* torture: cripple the kernel-side send buffer so we can only squeeze out


### PR DESCRIPTION
These commits fix a bug with keep-alive requests and substantially improve their throughput.

# Fix hung connection from consecutive requests

A client making quick consecutive requests with keep-alive, such as `ab`
with `-k`, can cause the connection to become hung.

This happens because of an optimization in `http_poll` function. When a
connection state becomes `DONE`, `httpd_poll` recycles the connection
and immediately calls `poll_recv_request`. However, it doesn't handle
this resulting in the connection state becoming `DONE` again. If this
occurs, the state stays in `DONE`, and the further calls to `httpd_poll`
ignore the connection.

Fix this by calling `poll_recv_request` in a loop until the state is no
longer `DONE`.

# Enable `TCP_NODELAY` optimization 

It looks like `TCP_NODELAY` was disabled due to the bug fixed in the
previous commit. Enabling it substantially improves keep-alive
performance with `ab`:

Before:

```
Time per request:       0.272 [ms] (mean)
```

After:

```
Time per request:       0.033 [ms] (mean)
```

# Remove keep-alive optimization from `httpd_poll`

Benchmarking with `ab` shows that bypassing `select` for keep-alive
connections in the `DONE` state doesn't significantly impact
performance. Since this optimization previously caused a bug, remove it.
