### PR TITLE
Fix high CPU usage when timeout is disabled

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -2518,6 +2518,9 @@ static void httpd_poll(void) {
 #endif
 
     /* -select- */
+    if (timeout_secs == 0) {
+        bother_with_timeout = 0;
+    }
     if (debug) {
         printf("select() with max_fd %d timeout %d\n",
                 max_fd, bother_with_timeout ? (int)timeout.tv_sec : 0);


### PR DESCRIPTION
When darkhttpd is running with `--timeout 0` (timeout disabled), and any
connection is idle, it will use 100% of the CPU. This happens because
`select` returns immediately when its timeout is zero, causing the main
`httpd_poll` loop to spin.

Fix this by adding a check to `httpd_poll` making `select` always
receive a `NULL` timeout when `timeout_secs` is zero.