### PR TITLE
Adding initial run with mimetypes and index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,17 @@
+<html>
+  <head>
+  <meta charset="utf-8">
+  <meta content="DarkHttpd demo page">
+    <title>DarkHttpd Works</title>    
+    <style>
+    body{background:#cfcfcf; color:#3300FF; padding: 10px;}
+    a{color:red;font-weight:bold}
+    a:hover{color:green}
+    </style>
+  </head>
+  <body>
+  <h1>DarkHttpd Server Works!</h1>
+  <p>When you need a web server in a hurry.</p>
+  <p>DarkHttpd on <a href="https://github.com/emikulic/darkhttpd">GitHub</a> | <a href="README.md">README</a></p>
+  </body>
+</html>

--- a/mimetypes
+++ b/mimetypes
@@ -1,0 +1,1 @@
+text/HTML  md 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,1 @@
+./darkhttpd ./ --port 9090 --mimetypes mimetypes


### PR DESCRIPTION
Initial run options after compile to get quick ride with the server. It includes `index.html`, `mimetypes` to be able to access a linked README.md and `run.sh` shell script to apply those initial run options. 