### PR TITLE
Update illumos support to the modern era

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC?=cc
 CFLAGS?=-O
-LIBS=`[ \`uname\` = "SunOS" ] && echo -lsocket -lnsl`
+LIBS=`[ \`uname\` = "SunOS" ] && echo -lsocket -lnsl -lsendfile`
 
 all: darkhttpd
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Simply run make:
 make
 ```
 
+If `cc` is not on your `PATH` as an alias to your C compiler, you may need to specify it. For example,
+
+```
+CC=gcc make
+```
+
 ## How to run darkhttpd
 
 Serve /var/www/htdocs on the default port (80 if running as root, else 8080):

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -381,16 +381,6 @@ static char *xstrdup(const char *src) {
     return dest;
 }
 
-#ifdef __sun /* unimpressed by Solaris */
-static int vasprintf(char **strp, const char *fmt, va_list ap) {
-    char tmp;
-    int result = vsnprintf(&tmp, 1, fmt, ap);
-    *strp = xmalloc(result+1);
-    result = vsnprintf(*strp, result+1, fmt, ap);
-    return result;
-}
-#endif
-
 /* vasprintf() that dies if it fails. */
 static unsigned int xvasprintf(char **ret, const char *format, va_list ap)
     __printflike(2,0);


### PR DESCRIPTION
This PR introduces 2 commits. The primary is 95d785acc1e4bc5f1b9ff8bda17ffb51b6f7a5f6. 

    Old versions of Solaris did not have vasprintf, so darkhttpd defined one
    gated behind an ifdef. Oracle Solaris 10 has had vasprintf since 2011.
    Oracle Solaris 11 has had it since release. illumos (which also reports
    as `__sun`) also has it in all current incarnations. As a result, this
    ifdef'd block creates compiler errors due to a second definition of the
    function. This commit removes the block.
    
    This commit also adds `-lsendfile` to the Makefile for systems that
    report as `SunOS` in `uname` (Solaris and Illumos), which is necessary
    to link successfully in current day

This should bring darkhttpd up to date with the current state of illumos and solaris and allow it to build on those systems. 

In the second commit I added a note to the README that `CC=<compiler> make` may be necessary if `cc` isn't a command on the system. For whatever reason, some variants of illumos I'm using don't have this. I need to look into that more, but in the mean time, I think it's a helpful tip.