### PR TITLE
Custom headers with the CLI option `--header`

### DIFF
--- a/devel/run-tests
+++ b/devel/run-tests
@@ -120,6 +120,21 @@ runtests() {
   kill $PID
   wait $PID
 
+  echo "===> run --header tests"
+  # Wrong flags:
+  ./a.out . --header >/dev/null 2>/dev/null
+  ./a.out . --header missing_colon >/dev/null 2>/dev/null
+  ./a.out . --header $'X-Header: Abusive\r\n\r\nBody' >/dev/null 2>/dev/null
+  # Correct flags:
+  ./a.out $DIR --port $PORT \
+    --header 'X-Header-A: First Value' --header 'X-Header-B: Second Value' \
+    >>test.out.stdout 2>>test.out.stderr &
+  PID=$!
+  kill -0 $PID || exit 1
+  python3 test_custom_headers.py
+  kill $PID
+  wait $PID
+
   echo "===> run --forward-https tests"
   ./a.out $DIR --port $PORT --forward-https \
     >>test.out.stdout 2>>test.out.stderr &

--- a/devel/test_custom_headers.py
+++ b/devel/test_custom_headers.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# This is run by the "run-tests" script.
+import unittest
+import os
+from test import WWWROOT, TestHelper, parse, random_bytes
+
+class TestCustomHeaders(TestHelper):
+    def setUp(self):
+        self.datalen = 2345
+        self.data = random_bytes(self.datalen)
+        self.url = '/data.jpeg'
+        self.fn = WWWROOT + self.url
+        with open(self.fn, 'wb') as f:
+            f.write(self.data)
+
+    def tearDown(self):
+        os.unlink(self.fn)
+
+    def test_custom_headers(self):
+        resp = self.get(self.url)
+        status, hdrs, body = parse(resp)
+        self.assertContains(status, '200 OK')
+        self.assertEqual(hdrs["Accept-Ranges"], "bytes")
+        self.assertEqual(hdrs["Content-Length"], str(self.datalen))
+        self.assertEqual(hdrs["Content-Type"], "image/jpeg")
+        self.assertEqual(hdrs["X-Header-A"], "First Value")
+        self.assertEqual(hdrs["X-Header-B"], "Second Value")
+        self.assertContains(hdrs["Server"], "darkhttpd/")
+        assert body == self.data, [self.url, resp, status, hdrs, body]
+        self.assertEqual(body, self.data)
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim:set ts=4 sw=4 et:


### PR DESCRIPTION
These changes add a command-line option `--header`, *e.g.* `--header 'Access-Control-Allow-Origin: \*'`.

Basic tests are included for this option.

When accepting the argument, a very simple sanitization is made, the string is required to contain
`": "`, and can’t contain a `'\n'` character. These checks are far from what is required to truly
validate a HTTP header, but will at least detect simple mistakes and forbid the abuse of having
arguments that including more than one header, or, worse, that included the body of the response.

This should also close the PR #27, I think, since the CORS functionality can be obtained by
specifying a custom header.
