### PR TITLE
Changes in default mimetypes

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -319,26 +319,36 @@ static gid_t drop_gid = INVALID_GID;
 
 /* Default mimetype mappings - make sure this array is NULL terminated. */
 static const char *default_extension_map[] = {
-    "application/ogg"      " ogg",
+    "application/json"     " json",
     "application/pdf"      " pdf",
     "application/wasm"     " wasm",
     "application/xml"      " xsl xml",
     "application/xml-dtd"  " dtd",
     "application/xslt+xml" " xslt",
     "application/zip"      " zip",
+    "audio/flac"           " flac",
     "audio/mpeg"           " mp2 mp3 mpga",
+    "audio/ogg"            " ogg opus oga spx",
+    "audio/wav"            " wav",
+    "audio/x-m4a"          " m4a",
+    "font/woff"            " woff",
+    "font/woff2"           " woff2",
+    "image/apng"           " apng",
+    "image/avif"           " avif",
     "image/gif"            " gif",
     "image/jpeg"           " jpeg jpe jpg",
     "image/png"            " png",
     "image/svg+xml"        " svg",
+    "image/webp"           " webp",
     "text/css"             " css",
     "text/html"            " html htm",
     "text/javascript"      " js",
     "text/plain"           " txt asc",
     "video/mpeg"           " mpeg mpe mpg",
     "video/quicktime"      " qt mov",
+    "video/webm"           " webm",
     "video/x-msvideo"      " avi",
-    "video/mp4"            " mp4",
+    "video/mp4"            " mp4 m4v",
     NULL
 };
 
@@ -1363,7 +1373,7 @@ static void log_connection(const struct connection *conn) {
         use_safe(user_agent)
         );
     fflush(logfile);
-  }    
+  }
 #define free_safe(x) if (safe_##x) free(safe_##x)
 
     free_safe(method);


### PR DESCRIPTION
 * Added mimetypes for image formats apng, avif, webp, webm.
 * Added mimetype for .json files.
 * Added default mimetypes for font/woff and font/woff2.
 * Changed .ogg from application/ogg to audio/ogg, which is more common.
 * Added audio/flac, audio/wav.
 * Added opus, oga, spx to audio/ogg.

Sources:
 * https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types
 * https://wiki.xiph.org/MIME_Types_and_File_Extensions
