### PR TITLE
Don't include wwwroot in directory list when in wwwroot

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1893,9 +1893,9 @@ static ssize_t make_sorted_dirlist(const char *path, struct dlent ***output) {
     while ((ent = readdir(dir)) != NULL) {
         struct stat s;
 
-        if (strncmp(path, wwwroot, strlen(path) - 1) == 0)
-            if (strcmp(ent->d_name, "..") == 0)
-                continue; /* skip wwwroot, when in wwwroot */
+        if ((strncmp(path, wwwroot, strlen(path) - 1) == 0) &&
+            (strcmp(ent->d_name, "..") == 0))
+                continue; /* skip "..", when in wwwroot */
         if (strcmp(ent->d_name, ".") == 0)
             continue; /* skip "." */
         assert(strlen(ent->d_name) <= MAXNAMLEN);

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1893,6 +1893,9 @@ static ssize_t make_sorted_dirlist(const char *path, struct dlent ***output) {
     while ((ent = readdir(dir)) != NULL) {
         struct stat s;
 
+        if (strncmp(path, wwwroot, strlen(path) - 1) == 0)
+            if (strcmp(ent->d_name, "..") == 0)
+                continue; /* skip wwwroot, when in wwwroot */
         if (strcmp(ent->d_name, ".") == 0)
             continue; /* skip "." */
         assert(strlen(ent->d_name) <= MAXNAMLEN);

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1895,7 +1895,7 @@ static ssize_t make_sorted_dirlist(const char *path, struct dlent ***output) {
 
         if ((strncmp(path, wwwroot, strlen(path) - 1) == 0) &&
             (strcmp(ent->d_name, "..") == 0))
-                continue; /* skip "..", when in wwwroot */
+            continue; /* skip "..", when in wwwroot */
         if (strcmp(ent->d_name, ".") == 0)
             continue; /* skip "." */
         assert(strlen(ent->d_name) <= MAXNAMLEN);


### PR DESCRIPTION
This will prevent `../` from showing up when already in wwwroot.
The string comparison is not super great, because path includes a trailing / and wwwroot does not. I don't think this is buggy, but it's not great.
Closes #33