### PR TITLE
Fix incorrect strlen check for wwwroot

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1071,7 +1071,7 @@ static void parse_commandline(const int argc, char *argv[]) {
     wwwroot = xstrdup(argv[1]);
     /* Strip ending slash. */
     len = strlen(wwwroot);
-    if (len > 0)
+    if (len > 1)
         if (wwwroot[len - 1] == '/')
             wwwroot[len - 1] = '\0';
 


### PR DESCRIPTION
Previously `./darkhttpd /` would set wwwroot to NULL. Which would still serve /, but I think this is how it was supposed to be in the first place.