### PR TITLE
Prevent user from setting wwwroot to NULL

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1072,7 +1072,7 @@ static void parse_commandline(const int argc, char *argv[]) {
     /* Strip ending slash. */
     len = strlen(wwwroot);
     if (len == 0)
-        errx(1, "wwwroot cannot be NULL");
+        errx(1, "/path/to/wwwroot cannot be empty");
     if (len > 1)
         if (wwwroot[len - 1] == '/')
             wwwroot[len - 1] = '\0';

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1071,7 +1071,7 @@ static void parse_commandline(const int argc, char *argv[]) {
     wwwroot = xstrdup(argv[1]);
     /* Strip ending slash. */
     len = strlen(wwwroot);
-    if (len > 0)
+    if (len > 1)
         if (wwwroot[len - 1] == '/')
             wwwroot[len - 1] = '\0';
 

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1071,6 +1071,8 @@ static void parse_commandline(const int argc, char *argv[]) {
     wwwroot = xstrdup(argv[1]);
     /* Strip ending slash. */
     len = strlen(wwwroot);
+    if (len == 0)
+        errx(1, "wwwroot cannot be NULL");
     if (len > 1)
         if (wwwroot[len - 1] == '/')
             wwwroot[len - 1] = '\0';


### PR DESCRIPTION
Do error when user gives NULL as input for wwwroot and fixed incorrect strlen check for wwwroot.

Previously `./darkhttpd /` and `./darkhttpd ''` would set wwwroot to NULL. Which would still serve /, but I think this is how it was supposed to be in the first place.