### PR TITLE
Correct maxlen for directories

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -2016,7 +2016,7 @@ static void generate_dir_listing(struct connection *conn, const char *path,
     char date[DATE_LEN], *spaces;
     struct dlent **list;
     ssize_t listsize;
-    size_t maxlen = 2; /* There has to be ".." */
+    size_t maxlen = 3; /* There has to be "../" */
     int i;
     struct apbuf *listing;
 
@@ -2038,7 +2038,7 @@ static void generate_dir_listing(struct connection *conn, const char *path,
     for (i=0; i<listsize; i++) {
         size_t tmp = strlen(list[i]->name);
         if (maxlen < tmp)
-            maxlen = tmp;
+            maxlen = tmp + (list[i]->is_dir && 1); /* add 1 for '/' */
     }
 
     listing = make_apbuf();

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -2016,7 +2016,7 @@ static void generate_dir_listing(struct connection *conn, const char *path,
     char date[DATE_LEN], *spaces;
     struct dlent **list;
     ssize_t listsize;
-    size_t maxlen = 3; /* There has to be "../" */
+    size_t maxlen = 3; /* There has to be ".." */
     int i;
     struct apbuf *listing;
 
@@ -2037,8 +2037,10 @@ static void generate_dir_listing(struct connection *conn, const char *path,
 
     for (i=0; i<listsize; i++) {
         size_t tmp = strlen(list[i]->name);
+        if (list[i]->is_dir)
+            tmp++; /* add 1 for '/' */
         if (maxlen < tmp)
-            maxlen = tmp + (list[i]->is_dir && 1); /* add 1 for '/' */
+            maxlen = tmp;
     }
 
     listing = make_apbuf();


### PR DESCRIPTION
In the directory listing the trailing '/' for directories is neglected when figuring out maxlen. This leads to missing space if a directory has the longest name.

This hange accounts for the trailing '/'