### PR TITLE
 display actual port again

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -886,7 +886,7 @@ static void init_sockin(void) {
         if (getsockname(sockin, (struct sockaddr *)&addrin6, &addrin_len) == -1)
             err(1, "getsockname()");
         printf("listening on: http://[%s]:%u/\n",
-            get_address_text(&addrin6.sin6_addr), bindport);
+            get_address_text(&addrin6.sin6_addr), ntohs(addrin.sin_port));
     } else
 #endif
     {
@@ -899,7 +899,7 @@ static void init_sockin(void) {
         if (getsockname(sockin, (struct sockaddr *)&addrin, &addrin_len) == -1)
             err(1, "getsockname()");
         printf("listening on: http://%s:%u/\n",
-            get_address_text(&addrin.sin_addr), bindport);
+            get_address_text(&addrin.sin_addr), ntohs(addrin.sin_port));
     }
 
     /* listen on socket */

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -886,7 +886,7 @@ static void init_sockin(void) {
         if (getsockname(sockin, (struct sockaddr *)&addrin6, &addrin_len) == -1)
             err(1, "getsockname()");
         printf("listening on: http://[%s]:%u/\n",
-            get_address_text(&addrin6.sin6_addr), ntohs(addrin.sin_port));
+            get_address_text(&addrin6.sin6_addr), ntohs(addrin6.sin6_port));
     } else
 #endif
     {


### PR DESCRIPTION
Print the initialized port instead of bindport variable. This is important when using `--port 0` for a random port.

I saw this commit https://github.com/emikulic/darkhttpd/commit/bcadc424a4ff240ef1dd09334ec73b47c6784416 and noticed that the code regressed.