### PR TITLE
Correct path check for ".."

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -2057,7 +2057,7 @@ static void generate_dir_listing(struct connection *conn, const char *path,
     memset(spaces, ' ', maxlen);
 
     /* append ".." entry if not in wwwroot */
-    if (strcmp(path, "./") != 0)
+    if (strncmp(path, wwwroot, strlen(path) - 1) != 0)
         append(listing, "<a href=\"../\">..</a>/\n");
 
     for (i=0; i<listsize; i++) {


### PR DESCRIPTION
Previously directory listing printed ".." when in wwwroot if wwwroot is not set to ".".
 So `./darkhttpd /dir` would have printed the "..".

Same solution like in #44

Sorry for the oversight