### PR TITLE
Add copyright notice to `COPYING`

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,3 +1,5 @@
+Copyright (c) 2003-2024 Emil Mikulic <emikulic@gmail.com>
+
 Permission to use, copy, modify, and distribute this software for any
 purpose with or without fee is hereby granted, provided that the
 above copyright notice and this permission notice appear in all


### PR DESCRIPTION
taken directly from darkhttpd.c

quoting the license:

> Permission to use, copy, modify, and distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.

but the copyright notice wasn't present before in the file at all
