### PR TITLE
strip the prefix from ipv4-mapped addresses

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -799,6 +799,10 @@ static const char *get_address_text(const void *addr) {
         static char text_addr[INET6_ADDRSTRLEN];
         const struct in6_addr *in6_addr = addr;
         inet_ntop(AF_INET6, in6_addr, text_addr, INET6_ADDRSTRLEN);
+        /* IPv4 addresses via dual stack result in mapped IPv6 addresses.
+           Strip the prefix (::ffff:) for plain IPv4 addresses. */
+        if (IN6_IS_ADDR_V4MAPPED(in6_addr))
+            return text_addr + 7;
         return text_addr;
     } else
 #endif

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -797,8 +797,8 @@ static const char *get_address_text(const void *addr) {
 #ifdef HAVE_INET6
     if (inet6) {
         static char text_addr[INET6_ADDRSTRLEN];
-        inet_ntop(AF_INET6, (const struct in6_addr *)addr, text_addr,
-                  INET6_ADDRSTRLEN);
+        const struct in6_addr *in6_addr = addr;
+        inet_ntop(AF_INET6, in6_addr, text_addr, INET6_ADDRSTRLEN);
         return text_addr;
     } else
 #endif


### PR DESCRIPTION
This allows to have plain IPv4 addresses in log, even if listening on an IPv6 socket.