### PR TITLE
Add js mimetype for mjs extension

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -368,7 +368,7 @@ static const char *default_extension_map[] = {
     "image/webp"           " webp",
     "text/css"             " css",
     "text/html"            " html htm",
-    "text/javascript"      " js",
+    "text/javascript"      " js mjs",
     "text/plain"           " txt asc",
     "video/mpeg"           " mpeg mpe mpg",
     "video/quicktime"      " qt mov",


### PR DESCRIPTION
Add the text/javascript mimetype also for the mjs file extension. The mjs file extension is commonly used to indicate JavaScript Modules [1]. It is recommended by V8 [2] and some tools require JavaScript Modules to have the mjs filename ending.

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules
[2] https://v8.dev/features/modules#mjs