### PR TITLE
Add --trusted-ip to log real client IP from X-Forwarded-For

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -262,6 +262,7 @@ struct connection {
 
     /* request fields */
     char *method, *url, *referer, *user_agent, *authorization;
+    char *forwarded_for;
     off_t range_begin, range_end;
     off_t range_begin_given, range_end_given;
 
@@ -332,6 +333,7 @@ static int want_chroot = 0, want_daemon = 0, want_accf = 0,
 static char *server_hdr = NULL;
 static char *auth_key = NULL;       /* NULL or "Basic base64_of_password" */
 static char *custom_hdrs = NULL;
+static char *trusted_ip = NULL;     /* Address of a trusted reverse proxy */
 static uint64_t num_requests = 0, total_in = 0, total_out = 0;
 static int accepting = 1;           /* set to 0 to stop accept()ing */
 static int syslog_enabled = 0;
@@ -1006,6 +1008,9 @@ static void usage(const char *argv0) {
     "\t\tEnable basic authentication. This is *INSECURE*: passwords\n"
     "\t\tare sent unencrypted over HTTP, plus the password is visible\n"
     "\t\tin ps(1) to other users on the system.\n\n");
+    printf("\t--trusted-ip ip\n"
+    "\t\tIf the request comes from this IP, the X-Forwarded-For header\n"
+    "\t\tcontent is used in the log instead of the connection peer IP.\n\n");
     printf("\t--header 'Header: Value'\n"
     "\t\tAdd a custom header to all responses.\n"
     "\t\tThis option can be specified multiple times, in which case\n"
@@ -1230,6 +1235,11 @@ static void parse_commandline(const int argc, char *argv[]) {
             xasprintf(&auth_key, "Basic %s", key);
             free(key);
         }
+        else if (strcmp(argv[i], "--trusted-ip") == 0) {
+            if (++i >= argc)
+                errx(1, "missing ip after --trusted-ip");
+            trusted_ip = argv[i];
+        }
         else if (strcmp(argv[i], "--forward-https") == 0) {
             forward_to_https = 1;
         }
@@ -1266,6 +1276,7 @@ static struct connection *new_connection(void) {
     conn->referer = NULL;
     conn->user_agent = NULL;
     conn->authorization = NULL;
+    conn->forwarded_for = NULL;
     conn->range_begin = 0;
     conn->range_end = 0;
     conn->range_begin_given = 0;
@@ -1392,6 +1403,8 @@ static char *clf_date(char *dest, const time_t when) {
 static void log_connection(const struct connection *conn) {
     char *safe_method, *safe_url, *safe_referer, *safe_user_agent,
     dest[CLF_DATE_LEN];
+    char *safe_forwarded = NULL;
+    const char *log_ip;
 
     if (logfile == NULL)
         return;
@@ -1399,6 +1412,22 @@ static void log_connection(const struct connection *conn) {
         return; /* invalid - died in request */
     if (conn->method == NULL)
         return; /* invalid - didn't parse - maybe too long */
+
+    /* Determine which IP to log */
+    log_ip = get_address_text(&conn->client);
+    if (trusted_ip != NULL && conn->forwarded_for != NULL) {
+        if (strcmp(log_ip, trusted_ip) == 0) {
+            /* X-Forwarded-For can be a comma separated list.
+               We want the first IP (the client), not the whole string. */
+            char *end;
+            if ((end = strchr(conn->forwarded_for, ',')) != NULL)
+                *end = '\0';
+
+            safe_forwarded = xmalloc(strlen(conn->forwarded_for) * 3 + 1);
+            logencode(conn->forwarded_for, safe_forwarded);
+            log_ip = safe_forwarded;
+        }
+    }
 
 #define make_safe(x) do { \
     if (conn->x) { \
@@ -1417,7 +1446,7 @@ static void log_connection(const struct connection *conn) {
 #define use_safe(x) safe_##x ? safe_##x : ""
   if (syslog_enabled) {
     syslog(LOG_INFO, "%s - - %s \"%s %s HTTP/1.1\" %d %llu \"%s\" \"%s\"\n",
-        get_address_text(&conn->client),
+        log_ip,
         clf_date(dest, now),
         use_safe(method),
         use_safe(url),
@@ -1428,7 +1457,7 @@ static void log_connection(const struct connection *conn) {
         );
   } else {
     fprintf(logfile, "%s - - %s \"%s %s HTTP/1.1\" %d %llu \"%s\" \"%s\"\n",
-        get_address_text(&conn->client),
+        log_ip,
         clf_date(dest, now),
         use_safe(method),
         use_safe(url),
@@ -1445,6 +1474,7 @@ static void log_connection(const struct connection *conn) {
     free_safe(url);
     free_safe(referer);
     free_safe(user_agent);
+    if (safe_forwarded != NULL) free(safe_forwarded);
 
 #undef make_safe
 #undef use_safe
@@ -1462,6 +1492,7 @@ static void free_connection(struct connection *conn) {
     if (conn->referer != NULL) free(conn->referer);
     if (conn->user_agent != NULL) free(conn->user_agent);
     if (conn->authorization != NULL) free(conn->authorization);
+    if (conn->forwarded_for != NULL) free(conn->forwarded_for);
     if (conn->header != NULL && !conn->header_dont_free) free(conn->header);
     if (conn->reply != NULL && !conn->reply_dont_free) free(conn->reply);
     if (conn->reply_fd != -1) xclose(conn->reply_fd);
@@ -1486,6 +1517,7 @@ static void recycle_connection(struct connection *conn) {
     conn->referer = NULL;
     conn->user_agent = NULL;
     conn->authorization = NULL;
+    conn->forwarded_for = NULL;
     conn->range_begin = 0;
     conn->range_end = 0;
     conn->range_begin_given = 0;
@@ -1932,6 +1964,7 @@ static int parse_request(struct connection *conn) {
     conn->referer = parse_field(conn, "Referer: ");
     conn->user_agent = parse_field(conn, "User-Agent: ");
     conn->authorization = parse_field(conn, "Authorization: ");
+    conn->forwarded_for = parse_field(conn, "X-Forwarded-For: ");
     parse_range_field(conn);
     return 1;
 }

--- a/devel/run-tests
+++ b/devel/run-tests
@@ -68,6 +68,26 @@ runtests() {
   kill $PID
   wait $PID
 
+  echo "===> run --log tests"
+  rm -f test_logging.log
+  ./a.out $DIR --port $PORT --addr $ADDR --log test_logging.log \
+    >>test.out.stdout 2>>test.out.stderr &
+  PID=$!
+  kill -0 $PID || exit 1
+  $PYTHON test_log.py || exit 1
+  kill $PID
+  wait $PID
+
+  echo "===> run --trusted-ip tests"
+  rm -f test_xff.log
+  ./a.out $DIR --port $PORT --addr $ADDR --log test_xff.log --trusted-ip $ADDR \
+    >>test.out.stdout 2>>test.out.stderr &
+  PID=$!
+  kill -0 $PID || exit 1
+  $PYTHON test_log_xff.py || exit 1
+  kill $PID
+  wait $PID
+
   echo "===> run --forward tests"
   ./a.out $DIR --port $PORT --addr $ADDR \
     --forward example.com http://www.example.com \

--- a/devel/test_log.py
+++ b/devel/test_log.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# This is run by the "run-tests" script.
+import unittest
+import os
+import time
+import random
+import string
+from test import TestHelper
+
+LOG_FILE = "test_logging.log"
+
+def random_str(n=10):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=n))
+
+class TestLog(TestHelper):
+    def _wait_and_check_log(self, unique_marker, timeout=2.0):
+        """
+        Polls the log file looking for a specific marker.
+        Returns the content of the log file if found.
+        """
+        start = time.time()
+        content = ""
+        while time.time() - start < timeout:
+            if os.path.exists(LOG_FILE):
+                with open(LOG_FILE, 'r', encoding='utf-8', errors='replace') as f:
+                    content = f.read()
+                    if unique_marker in content:
+                        return content
+            time.sleep(0.1)
+        
+        # If we fail, print the content we did find to help debugging
+        self.fail(f"Marker '{unique_marker}' not found in {LOG_FILE} within {timeout}s.\nLog content:\n{content}")
+
+    def test_log_sanitization_quotes(self):
+        """
+        Security Test: Log Injection Protection.
+        Double quotes in headers (like Referer) must be hex-encoded (%22).
+        If not encoded, an attacker could "break out" of the log format strings.
+        """
+        unique_id = random_str()
+        # We use Referer because TestHelper might enforce its own User-Agent
+        bad_referer = f'Ref-{unique_id} "hacker"'
+        # Expectation: Quotes are replaced by %22
+        expected_part = f'Ref-{unique_id} %22hacker%22'
+
+        self.get("/sanit_quote", req_hdrs={"Referer": bad_referer})
+        
+        content = self._wait_and_check_log(unique_id)
+        self.assertIn(expected_part, content, 
+                      "Double quotes in Referer must be escaped as %22 to prevent log injection.")
+
+    def test_log_truncation_newlines(self):
+        """
+        Security Test: Log Injection Protection via Newlines.
+        
+        darkhttpd parses headers by reading until \r or \n. 
+        Therefore, if a client sends a header with a newline, darkhttpd 
+        should stop parsing the value at that point.
+        
+        The result should be a truncated log entry, NOT a new log line (injection).
+        """
+        unique_id = random_str()
+        injection_attempt = "127.0.0.1 - - [FAKE LOG ENTRY]"
+        
+        # We try to inject a newline into the Referer.
+        # darkhttpd is expected to stop parsing at \n.
+        bad_referer = f"Start-{unique_id}\n{injection_attempt}"
+        
+        self.get("/sanit_newline", req_hdrs={"Referer": bad_referer})
+
+        content = self._wait_and_check_log(unique_id)
+        
+        # 1. Verify truncation: We should see the start, but NOT the injection attempt in the same string context
+        # darkhttpd logic: splits header at \n. 'Referer' becomes just "Start-{unique_id}"
+        self.assertIn(f"Start-{unique_id}", content)
+        self.assertNotIn(injection_attempt, content, 
+                         "The part after the newline should not appear in the log (header parsing should stop at newline).")
+        
+        # 2. Verify no duplicate unique_id (ensure the line didn't split into two valid looking lines)
+        count = content.count(unique_id)
+        self.assertEqual(count, 1, "Injection should not result in duplicate markers.")
+
+    def test_empty_headers(self):
+        """
+        Test that empty headers are logged as empty quotes "" rather than skipped or malformed.
+        """
+        unique_url = f"/empty_hdrs_{random_str()}"
+        
+        # We explicitly set Referer to empty. 
+        # Note: We don't test User-Agent here because TestHelper/Python requests 
+        # usually force a default python UA if one isn't provided or is empty.
+        self.get(unique_url, req_hdrs={"Referer": ""})
+        
+        content = self._wait_and_check_log(unique_url)
+        
+        found_line = False
+        for line in content.splitlines():
+            if unique_url in line:
+                found_line = True
+                # Format is: ... "REFERER" "USER_AGENT"
+                # If Referer is empty, we expect: ... "" "..."
+                self.assertIn('"" "', line, 
+                              f"Empty Referer should be logged as \"\". Logged line: {line}")
+                break
+        
+        self.assertTrue(found_line, "Could not find the specific log line for empty headers test.")
+
+    def test_xff_ignored_by_default(self):
+        """
+        Security Test: X-Forwarded-For must be IGNORED by default.
+        
+        Unless the server is started with --trusted-ip, it must log the 
+        actual connection IP (127.0.0.1), not the spoofed header.
+        """
+        fake_ip = "10.6.6.6"
+        unique_url = f"/xff_test_{random_str()}"
+        
+        self.get(unique_url, req_hdrs={"X-Forwarded-For": fake_ip})
+        
+        content = self._wait_and_check_log(unique_url)
+        
+        target_line = ""
+        for line in content.splitlines():
+            if unique_url in line:
+                target_line = line
+                break
+        
+        self.assertTrue(target_line, "Log line not found for XFF test")
+        
+        # Log starts with IP. Check it is 127.0.0.1
+        self.assertTrue(target_line.startswith("127.0.0.1"), 
+                        f"Server must log real IP (127.0.0.1) by default. Logged: {target_line}")
+        
+        self.assertNotIn(fake_ip, target_line, 
+                         "Spoofed X-Forwarded-For IP must not appear in log by default.")
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim:set ts=4 sw=4 et:

--- a/devel/test_log_xff.py
+++ b/devel/test_log_xff.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# This is run by the "run-tests" script.
+import unittest
+import os
+import time
+import random
+import string
+from test import TestHelper
+
+LOG_FILE = "test_xff.log"
+
+def random_str(n=10):
+    return ''.join(random.choices(string.ascii_letters + string.digits, k=n))
+
+class TestTrustedIp(TestHelper):
+    def _wait_and_check_log(self, unique_marker, timeout=2.0):
+        """
+        Polls the log file looking for a specific marker.
+        Returns the specific log line containing the marker if found.
+        """
+        start = time.time()
+        content = ""
+        while time.time() - start < timeout:
+            if os.path.exists(LOG_FILE):
+                with open(LOG_FILE, 'r', encoding='utf-8', errors='replace') as f:
+                    content = f.read()
+                    if unique_marker in content:
+                        # Find and return only the specific line containing the unique marker
+                        for line in content.splitlines():
+                            if unique_marker in line:
+                                return line
+            time.sleep(0.1)
+        # If we fail, print the content we did find to help debugging
+        self.fail(f"Marker '{unique_marker}' not found in {LOG_FILE} within {timeout}s.\nLog content:\n{content}")
+
+
+    def test_xff_single_ipv4(self):
+        """
+        Test that a single IPv4 address in X-Forwarded-For is logged.
+        """
+        fake_ip = "10.10.10.10"
+        time_marker = random_str()
+        url = f"/xff_single-{time_marker}"
+        
+        self.get(url, req_hdrs={"X-Forwarded-For": fake_ip})
+        
+        line = self._wait_and_check_log(url)
+        # Log line format: IP - - [DATE] "GET ..."
+        self.assertTrue(line.startswith(fake_ip + " "), 
+            f"Expected log to start with {fake_ip}, but got: {line}")
+
+    def test_xff_multiple_ipv4(self):
+        """
+        Test a comma-separated list of IPv4 addresses.
+        The C code uses 'strchr' to find the first comma and effectively
+        truncates the string there. We expect only the first IP to be logged.
+        """
+        client_ip = "1.2.3.4"
+        proxy_ip = "5.6.7.8"
+        # Standard XFF format: client, proxy1, proxy2
+        header_val = f"{client_ip}, {proxy_ip}, {proxy_ip}"
+        
+        time_marker = random_str()
+        url = f"/xff_multi-{time_marker}"
+        
+        self.get(url, req_hdrs={"X-Forwarded-For": header_val})
+        
+        line = self._wait_and_check_log(url)
+        
+        # Should start with the client IP
+        self.assertTrue(line.startswith(client_ip + " "), 
+            f"Expected log to start with first IP ({client_ip}). Log line: {line}")
+        
+        # Should NOT contain the proxy IP (it should be stripped)
+        self.assertNotIn(proxy_ip, line, 
+            "The second IP in the list should be stripped from the log.")
+
+    def test_xff_ipv6(self):
+        """
+        Test a single IPv6 address. 
+        Important to ensure logic doesn't break on colons (:).
+        """
+        ipv6 = "2001:db8::1"
+        time_marker = random_str()
+        url = f"/xff_ipv6-{time_marker}"
+        
+        self.get(url, req_hdrs={"X-Forwarded-For": ipv6})
+        
+        line = self._wait_and_check_log(url)
+        self.assertTrue(line.startswith(ipv6 + " "), 
+            f"Expected log to start with IPv6 {ipv6}. Log line: {line}")
+
+    def test_xff_ipv6_list(self):
+        """
+        Test a list containing IPv6 and IPv4.
+        Ensures the comma logic works when the first element is a long IPv6 string.
+        """
+        client_ipv6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        proxy_ip = "192.168.1.1"
+        header_val = f"{client_ipv6}, {proxy_ip}"
+        
+        time_marker = random_str()
+        url = f"/xff_ipv6_list-{time_marker}"
+        
+        self.get(url, req_hdrs={"X-Forwarded-For": header_val})
+        
+        line = self._wait_and_check_log(url)
+        self.assertTrue(line.startswith(client_ipv6 + " "), 
+            f"Expected log to start with {client_ipv6}. Log line: {line}")
+        self.assertNotIn(proxy_ip, line)
+
+if __name__ == '__main__':
+    unittest.main()
+
+# vim:set ts=4 sw=4 et:


### PR DESCRIPTION
This option is very useful when working behind a reverse proxy.

Perhaps it should be enabled by default for the `127.0.0.1` address. But I'm not sure about that.