### PR TITLE
fix: match parse_field header names only at line starts

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1778,28 +1778,18 @@ static void redirect(struct connection *conn, const char *format, ...) {
  */
 static char *parse_field(const struct connection *conn, const char *field) {
     size_t bound1, bound2;
-    const size_t field_len = strlen(field);
-    char *pos = NULL;
+    char *search, *pos;
 
-    /* Walk header lines: only match [field] at the start of a line so that
-     * substrings inside the request-target or another header's value cannot
-     * be mistaken for a real header. The first line is the request line and
-     * will not match any of the header names we look for. */
-    for (size_t i = 0; i + field_len <= conn->request_length; ) {
-        if (strncasecmp(conn->request + i, field, field_len) == 0) {
-            pos = conn->request + i;
-            break;
-        }
-        /* Advance to the byte after the next '\n', or stop if none. */
-        const char *nl = memchr(conn->request + i, '\n',
-                                conn->request_length - i);
-        if (nl == NULL)
-            break;
-        i = (size_t)(nl - conn->request) + 1;
-    }
+    /* Prepend '\n' so strcasestr only matches [field] at the start of a line,
+     * preventing substrings inside the request-target or another header's
+     * value from being mistaken for a real header. */
+    xasprintf(&search, "\n%s", field);
+    pos = strcasestr(conn->request, search);
+    free(search);
     if (pos == NULL)
         return NULL;
-    bound1 = (size_t)(pos - conn->request) + field_len;
+    pos++;  /* skip the leading '\n' */
+    bound1 = (size_t)(pos - conn->request) + strlen(field);
 
     /* find end */
     for (bound2 = bound1;

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1778,14 +1778,28 @@ static void redirect(struct connection *conn, const char *format, ...) {
  */
 static char *parse_field(const struct connection *conn, const char *field) {
     size_t bound1, bound2;
-    char *pos;
+    const size_t field_len = strlen(field);
+    char *pos = NULL;
 
-    /* find start */
-    pos = strcasestr(conn->request, field);
+    /* Walk header lines: only match [field] at the start of a line so that
+     * substrings inside the request-target or another header's value cannot
+     * be mistaken for a real header. The first line is the request line and
+     * will not match any of the header names we look for. */
+    for (size_t i = 0; i + field_len <= conn->request_length; ) {
+        if (strncasecmp(conn->request + i, field, field_len) == 0) {
+            pos = conn->request + i;
+            break;
+        }
+        /* Advance to the byte after the next '\n', or stop if none. */
+        const char *nl = memchr(conn->request + i, '\n',
+                                conn->request_length - i);
+        if (nl == NULL)
+            break;
+        i = (size_t)(nl - conn->request) + 1;
+    }
     if (pos == NULL)
         return NULL;
-    assert(pos >= conn->request);
-    bound1 = (size_t)(pos - conn->request) + strlen(field);
+    bound1 = (size_t)(pos - conn->request) + field_len;
 
     /* find end */
     for (bound2 = bound1;

--- a/devel/test_log_xff.py
+++ b/devel/test_log_xff.py
@@ -90,6 +90,30 @@ class TestTrustedIp(TestHelper):
         self.assertTrue(line.startswith(ipv6 + " "), 
             f"Expected log to start with IPv6 {ipv6}. Log line: {line}")
 
+    def test_xff_smuggled_in_referer(self):
+        """
+        A client without a real X-Forwarded-For header must not be able to
+        spoof its logged IP by smuggling the field name inside another
+        header's value (here: Referer). The log must show the real client
+        IP, not the smuggled one.
+        """
+        spoof_ip = "99.99.99.99"
+        time_marker = random_str()
+        url = f"/xff_smuggle-{time_marker}"
+
+        # No X-Forwarded-For header is sent; the substring lives inside
+        # the Referer value. Pre-fix parse_field used strcasestr() over
+        # the whole request and would match this.
+        self.get(url, req_hdrs={"Referer": f"X-Forwarded-For: {spoof_ip}"})
+
+        line = self._wait_and_check_log(url)
+        self.assertFalse(line.startswith(spoof_ip + " "),
+            f"Spoofed IP {spoof_ip} smuggled via Referer was logged as the "
+            f"client address. Log line: {line}")
+        self.assertTrue(line.startswith("127.0.0.1 "),
+            f"Expected log to start with real client IP 127.0.0.1. "
+            f"Log line: {line}")
+
     def test_xff_ipv6_list(self):
         """
         Test a list containing IPv6 and IPv4.

--- a/devel/test_log_xff.py
+++ b/devel/test_log_xff.py
@@ -114,6 +114,34 @@ class TestTrustedIp(TestHelper):
             f"Expected log to start with real client IP 127.0.0.1. "
             f"Log line: {line}")
 
+    def test_xff_real_header_not_masked_by_prior_value_match(self):
+        """
+        When the field name appears inside a prior header's value *and* a real
+        X-Forwarded-For header is also present, the real header must still be
+        found. A single-hit approach (find the first strcasestr match, check
+        pos[-1] != '\\n', stop) would reject that hit and return NULL, losing
+        the real header entirely.
+        """
+        real_ip = "10.20.30.40"
+        spoof_ip = "99.99.99.99"
+        time_marker = random_str()
+        url = f"/xff_masked-{time_marker}"
+
+        # Referer value contains "X-Forwarded-For: <spoof_ip>" as a substring.
+        # The real X-Forwarded-For header comes after.
+        self.get(url, req_hdrs={
+            "Referer": f"http://evil.example/X-Forwarded-For: {spoof_ip}",
+            "X-Forwarded-For": real_ip,
+        })
+
+        line = self._wait_and_check_log(url)
+        self.assertTrue(line.startswith(real_ip + " "),
+            f"Expected log to start with real XFF IP {real_ip}. "
+            f"Log line: {line}")
+        self.assertFalse(line.startswith(spoof_ip + " "),
+            f"Spoofed IP {spoof_ip} (embedded in Referer value) was logged. "
+            f"Log line: {line}")
+
     def test_xff_ipv6_list(self):
         """
         Test a list containing IPv6 and IPv4.


### PR DESCRIPTION
Fixes #94.

## Summary

- `parse_field()` used `strcasestr` over the whole request buffer, so any substring matching a header name was accepted — including bytes inside the request-target or another header's value. This let clients smuggle `Authorization`, `Range`, `X-Forwarded-For`, `Host`, `If-Modified-Since`, etc.
- Most impactful: with `--trusted-ip`, a client whose connection matches the trusted proxy address could spoof its logged IP by hiding `X-Forwarded-For: <ip>` inside a header it controls (e.g. `Referer`), without ever sending a real `X-Forwarded-For`.
- Fix: walk header lines and only match the field name at the start of a line (`strncasecmp` after each `\n`). The request line itself never matches a header name.

Repro (pre-fix, server started with `--trusted-ip 127.0.0.1`, client on 127.0.0.1):

```
printf 'GET / HTTP/1.0\r\nHost: x\r\nReferer: X-Forwarded-For: 99.99.99.99\r\n\r\n' \
  | nc 127.0.0.1 18080
```

logs `99.99.99.99 - - ... "GET / ..." 200 ... "X-Forwarded-For: 99.99.99.99" ""`. Post-fix, real client IP is logged.

## Test plan

- [x] Added `test_xff_smuggled_in_referer` to `devel/test_log_xff.py`. Fails on `7b9cafa` (vulnerable), passes after the fix.
- [x] All 5 existing `test_log_xff.py` cases still pass.
- [x] Smoke-tested manually with `--trusted-ip 127.0.0.1` for both the smuggling attempt and a legitimate `X-Forwarded-For: 1.2.3.4` header.