### PR TITLE
fix: drop unnecessary *ret check in xvasprintf error path

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -434,7 +434,7 @@ static unsigned int xvasprintf(char **ret, const char *format, va_list ap)
     __printflike(2,0);
 static unsigned int xvasprintf(char **ret, const char *format, va_list ap) {
     int len = vasprintf(ret, format, ap);
-    if (ret == NULL || len == -1)
+    if (len == -1 || *ret == NULL)
         errx(1, "out of memory in vasprintf()");
     return (unsigned int)len;
 }

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -434,7 +434,7 @@ static unsigned int xvasprintf(char **ret, const char *format, va_list ap)
     __printflike(2,0);
 static unsigned int xvasprintf(char **ret, const char *format, va_list ap) {
     int len = vasprintf(ret, format, ap);
-    if (len == -1 || *ret == NULL)
+    if (len == -1)
         errx(1, "out of memory in vasprintf()");
     return (unsigned int)len;
 }


### PR DESCRIPTION
`ret` is the address of a local `char*` and is never NULL, so the OOM branch was dead. Test `len == -1` first to short-circuit, since per `vasprintf(3)` the contents of `*strp` are undefined on error on GNU; the `*ret == NULL` check then covers the FreeBSD case, where the implementation sets `strp` to NULL on error.