### PR TITLE
fix: reject requests with malformed request-line

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1949,6 +1949,8 @@ static int parse_request(struct connection *conn) {
             bound2++)
                 ;
 
+        if (conn->request[bound2] != '\r' && conn->request[bound2] != '\n')
+            return 0; /* extra tokens after HTTP version */
         proto = split_string(conn->request, bound1, bound2);
         if (strcasecmp(proto, "HTTP/1.1") == 0)
             conn->conn_close = 0;
@@ -1957,8 +1959,6 @@ static int parse_request(struct connection *conn) {
             return 0; /* unknown version or literal space in request-target */
         }
         free(proto);
-        if (conn->request[bound2] != '\r' && conn->request[bound2] != '\n')
-            return 0; /* extra tokens after HTTP version */
     }
 
     /* parse connection field */

--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1944,14 +1944,21 @@ static int parse_request(struct connection *conn) {
         for (bound2 = bound1 + 1;
             (bound2 < conn->request_length) &&
             (conn->request[bound2] != ' ') &&
-            (conn->request[bound2] != '\r');
+            (conn->request[bound2] != '\r') &&
+            (conn->request[bound2] != '\n');
             bound2++)
                 ;
 
         proto = split_string(conn->request, bound1, bound2);
         if (strcasecmp(proto, "HTTP/1.1") == 0)
             conn->conn_close = 0;
+        else if (strcasecmp(proto, "HTTP/1.0") != 0) {
+            free(proto);
+            return 0; /* unknown version or literal space in request-target */
+        }
         free(proto);
+        if (conn->request[bound2] != '\r' && conn->request[bound2] != '\n')
+            return 0; /* extra tokens after HTTP version */
     }
 
     /* parse connection field */
@@ -2519,6 +2526,7 @@ static void process_request(struct connection *conn) {
     num_requests++;
 
     if (!parse_request(conn)) {
+        conn->conn_close = 1;
         default_reply(conn, 400, "Bad Request",
             "You sent a request that the server couldn't understand.");
     }

--- a/devel/test.py
+++ b/devel/test.py
@@ -255,6 +255,7 @@ def setUpModule():
         ["invalid up dir",       "/../",            "assertIsInvalid"],
         ["fancy invalid up dir", "/./dir/./../../", "assertIsInvalid"],
         ["ascii nul",            "/\x00/",          "assertBadRequest"],
+        ["space in url",         "/foo bar",        "assertBadRequest"],
         ["extra slashes 2",      "//.d",            "assertNotFound"],
         ["not found",            "/not_found.txt",  "assertNotFound"],
         ["not found dir",        "/not_found/",     "assertNotFound"],
@@ -262,6 +263,25 @@ def setUpModule():
         ["unreadable",           "/unreadable/",    "assertForbidden"],
         ]:
         makeSimpleCases(*args)
+
+class TestMalformedRequestLine(TestHelper):
+    def _raw(self, request_line):
+        c = Conn()
+        c.s.send((request_line + "\r\n\r\n").encode("utf-8"))
+        resp = b""
+        while True:
+            signal.alarm(1)
+            r = c.s.recv(65536)
+            signal.alarm(0)
+            if not r:
+                break
+            resp += r
+        c.close()
+        return resp
+
+    def test_extra_token_after_version(self):
+        resp = self._raw("GET / HTTP/1.1 HTTP/1.1\r\nConnection: close")
+        self.assertBadRequest(resp, "/")
 
 class TestDirRedirect(TestHelper):
     def setUp(self):


### PR DESCRIPTION
Fixes #99.

`parse_request()` stopped URL parsing at the first space, then treated the next token as the HTTP version. This allowed a literal space in the request-target to go undetected — the server would silently truncate the URL and continue. Additionally, extra tokens after the HTTP version (e.g. `GET / HTTP/1.1 HTTP/1.1`) were silently ignored.

## Changes

**`darkhttpd.c`**
- Accept only `HTTP/1.0` or `HTTP/1.1` as valid version tokens (previously accepted any `HTTP/` prefix). An unrecognised token means the URL contained a literal space → 400.
- Reject the request if a non-whitespace character follows the version on the same line (extra tokens).
- Stop the version-token loop at `\n` so bare-LF requests are handled symmetrically with CRLF.
- Force `conn_close = 1` in `process_request()` when `parse_request()` fails, so the 400 reply always closes the connection (previously, if `HTTP/1.1` had been parsed before the failure, the connection was incorrectly kept alive).

**`devel/test.py`**
- Table entry for `GET /foo bar HTTP/1.1` → 400.
- `TestMalformedRequestLine.test_extra_token_after_version`: sends `GET / HTTP/1.1 HTTP/1.1` via raw socket → 400.