### PR TITLE
Sanitize redirect URLs to prevent XSS and header injection

### DIFF
--- a/darkhttpd.c
+++ b/darkhttpd.c
@@ -1728,15 +1728,54 @@ static void default_reply(struct connection *conn,
     conn->reply_start = 0;
 }
 
+static char *html_escape(const char *src) {
+    size_t i, len = strlen(src), alloc = len;
+    char *out;
+    for (i = 0; i < len; i++) {
+        switch (src[i]) {
+            case '<': case '>': alloc += 3; break;
+            case '&': alloc += 4; break;
+            case '"': case '\'': alloc += 5; break;
+        }
+    }
+    out = xmalloc(alloc + 1);
+    size_t pos = 0;
+    for (i = 0; i < len; i++) {
+        switch (src[i]) {
+            case '<':  memcpy(out+pos, "&lt;", 4); pos += 4; break;
+            case '>':  memcpy(out+pos, "&gt;", 4); pos += 4; break;
+            case '&':  memcpy(out+pos, "&amp;", 5); pos += 5; break;
+            case '"':  memcpy(out+pos, "&quot;", 6); pos += 6; break;
+            case '\'': memcpy(out+pos, "&apos;", 6); pos += 6; break;
+            default:   out[pos++] = src[i]; break;
+        }
+    }
+    out[pos] = '\0';
+    return out;
+}
+
+static void strip_crlf(char *s) {
+    size_t r = 0, w = 0;
+    while (s[r] != '\0') {
+        if (s[r] != '\r' && s[r] != '\n')
+            s[w++] = s[r];
+        r++;
+    }
+    s[w] = '\0';
+}
+
 static void redirect(struct connection *conn, const char *format, ...)
     __printflike(2, 3);
 static void redirect(struct connection *conn, const char *format, ...) {
-    char *where, date[DATE_LEN];
+    char *where, *where_escaped, date[DATE_LEN];
     va_list va;
 
     va_start(va, format);
     xvasprintf(&where, format, va);
     va_end(va);
+
+    strip_crlf(where);
+    where_escaped = html_escape(where);
 
     /* Only really need to calculate the date once. */
     rfc1123_date(date, now);
@@ -1744,11 +1783,11 @@ static void redirect(struct connection *conn, const char *format, ...) {
     conn->reply_length = xasprintf(&(conn->reply),
      "<!DOCTYPE html><html><head><title>301 Moved Permanently</title></head><body>\n"
      "<h1>Moved Permanently</h1>\n"
-     "Moved to: <a href=\"%s\">%s</a>\n" /* where x 2 */
+     "Moved to: <a href=\"%s\">%s</a>\n" /* where_escaped x 2 */
      "<hr>\n"
      "%s" /* generated on */
      "</body></html>\n",
-     where, where, generated_on(date));
+     where_escaped, where_escaped, generated_on(date));
 
     conn->header_length = xasprintf(&(conn->header),
      "HTTP/1.1 301 Moved Permanently\r\n"
@@ -1764,6 +1803,7 @@ static void redirect(struct connection *conn, const char *format, ...) {
      date, server_hdr, where, keep_alive(conn),
      custom_hdrs, llu(conn->reply_length));
 
+    free(where_escaped);
     free(where);
     conn->reply_type = REPLY_GENERATED;
     conn->http_code = 301;


### PR DESCRIPTION
## Summary

- Fix reflected XSS in redirect response bodies (CWE-79)
- Fix HTTP response splitting via CRLF injection in redirect Location header (CWE-113)

Both issues affect the `redirect()` function when `--forward`, `--forward-all`, or `--https-redirect` is configured. URL-decoded paths are placed unsanitized into both the HTML body and the `Location` header.

## Changes

- Add `html_escape()` to encode `< > & " '` in the HTML response body
- Add `strip_crlf()` to remove `\r` and `\n` from the `Location` header value
- The existing `append_escaped()` in `generate_dir_listing()` uses the `apbuf` interface and cannot be reused here

## Test

```
# Start with forwarding enabled
./darkhttpd /tmp/test --port 8080 --forward-all http://example.com

# XSS: body should show &lt;script&gt; (escaped), not raw <script>
curl -D- "http://127.0.0.1:8080/%3Cscript%3Ealert(1)%3C/script%3E"

# CRLF: Set-Cookie should appear inside Location value, not as separate header
curl -D- "http://127.0.0.1:8080/%0d%0aSet-Cookie:%20evil=1"
```